### PR TITLE
Connect Dify API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Copy this file to .env.local and add your keys
+DIFY_API_KEY=
+# DIFY_API_URL=https://api.dify.ai/v1/chat/completions

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ yarn-error.log*
 
 # env files
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -28,3 +28,14 @@ Continue building your app on:
 2. Deploy your chats from the v0 interface
 3. Changes are automatically pushed to this repository
 4. Vercel deploys the latest version from this repository
+
+## Dify Integration
+
+To enable AI responses powered by [Dify](https://docs.dify.ai/):
+
+1. Copy `.env.example` to `.env.local`.
+2. Edit `.env.local` and provide your `DIFY_API_KEY` (and optionally
+   `DIFY_API_URL`).
+
+With these variables configured, the frontend will send user questions to
+`/api/chat`, which proxies requests to Dify's chat completion API.

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+
+export async function POST(request: Request) {
+  try {
+    const { message } = await request.json();
+
+    const apiKey = process.env.DIFY_API_KEY;
+    const apiUrl = process.env.DIFY_API_URL ?? "https://api.dify.ai/v1/chat/completions";
+
+    if (!apiKey) {
+      return NextResponse.json({ error: "Missing DIFY_API_KEY" }, { status: 500 });
+    }
+
+    const res = await fetch(apiUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        messages: [{ role: "user", content: message }],
+      }),
+    });
+
+    const data = await res.json();
+
+    return NextResponse.json(data, { status: res.status });
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- add `/api/chat` route that proxies to Dify
- fetch Dify responses in `handleSubmit`
- allow `animateMessage` to optionally advance the demo script
- document `DIFY_API_KEY` in README
- add example env file and fix README newline
- clarify how to set up the Dify environment variables

## Testing
- `pnpm build` *(fails: next not found)*
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68545ae034c4832ba2f708645aefe06d